### PR TITLE
Update documentation for CSRF challenge

### DIFF
--- a/appendix/solutions.md
+++ b/appendix/solutions.md
@@ -536,10 +536,9 @@ verbose = true
 
 ### Change the name of a user by performing Cross-Site Request Forgery from another origin
 
-1. Open Juice Shop in an older web browser, e.g.
-   [Mozilla Firefox 56](https://ftp.mozilla.org/pub/firefox/releases/56.0/)
-   from 2017. _(⚠️ You should not install such an old browser on your
-   actual computer! Use a VM for such experiments!)_
+1. Open Juice Shop in a web browser which sets cookies with `SameSite=None`
+   by default (Firefox should be fine, see remarks in challenge
+   description).
 2. Login with any user account. This user is going to be the victim of
    the CSRF attack.
 3. Navigate to <http://htmledit.squarefree.com> in the same browser. It

--- a/part2/broken-access-control.md
+++ b/part2/broken-access-control.md
@@ -70,13 +70,27 @@ lower half.
 * Write the code for the CSRF attack within
   <http://htmledit.squarefree.com> and verify that it changes your
   username.
-* You might only succeed executing this attack when using a sufficiently
-  old browser brand or version.
-
-_Please be aware that the challenge is designed to be solved only with
+  
+_Please also be aware that the challenge is designed to be solved only with
 the specified online HTML editor. This means that Juice Shop will not
 recognize the challenge as solved when you are using another origin,
 such as for example JSFiddle or CodePen._
+
+#### ⚠️ Important information about browser compatibility
+
+There is an ongoing initiative, called "Incrementally Better
+Cookies", which aims to reduce the impact of CSRF attacks by changing
+the default cookie handling of browsers. It is strongly recommended to
+understand these changes before attempting this challenge, as otherwise
+it might not be solvable:
+* An overview of the planned changes to `SameSite` can be found in https://web.dev/samesite-cookie-recipes/.
+* At the time of this writing, the challenge should work fine with Firefox.
+* If you are in doubt, you can check the behavior of your browser using
+  the website https://samesite-sandbox.glitch.me/ - if you see the text
+  "set ❌" in the first row below the column "Cross-site?", your browser
+  uses the old default and should be able to solve the challenge.
+* Chrome can be temporarily switched back to the old behavior by starting
+  it with the option `--disable-features=SameSiteByDefaultCookies`.
 
 ### Find the hidden easter egg
 


### PR DESCRIPTION
As discussed in bkimminich/juice-shop#1592, the description of the CSRF challenge needs to be updated. The challenge description now provides more details about the `SameSite` issue so that users can learn about it and solve the challenge more easily.